### PR TITLE
docs: update all docs for Stacks v2 protocol support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,45 +1,29 @@
-# =============================================================================
-# x402 Cross-Chain Example - Environment Variables
-# =============================================================================
-# Copy this file to .env and fill in your values
-
-# =============================================================================
 # Server Configuration
-# =============================================================================
+# ====================
 
-# Address to receive EVM payments (Base network)
-SERVER_ADDRESS_EVM=0xYourEvmAddressHere
+# EVM (Base) payment address
+SERVER_ADDRESS_EVM=0xYourEVMAddressHere
 
-# Address to receive Stacks payments
+# Stacks payment address
 SERVER_ADDRESS_STACKS=SPYourStacksAddressHere
 
-# =============================================================================
-# Network Configuration
-# =============================================================================
-
-# Stacks network: "testnet" or "mainnet"
+# Network configuration
 STACKS_NETWORK=testnet
 
-# EVM RPC URL (Base Sepolia for testnet, Base for mainnet)
+# RPC and Facilitator URLs
 EVM_RPC_URL=https://sepolia.base.org
-
-# =============================================================================
-# Facilitator URLs
-# =============================================================================
-
-# v2 facilitator (EVM, Solana)
 EVM_FACILITATOR_URL=https://x402.org/facilitator
-
-# v1 facilitator (Stacks)
 STACKS_FACILITATOR_URL=https://facilitator.stacksx402.com
 
-# =============================================================================
-# Client Credentials (for testing only - do not use in production)
-# =============================================================================
+# Client Testing (optional)
+# =========================
 
-# EVM client private key (for testing EVM payments)
+# EVM client private key (for testing payments)
 CLIENT_PRIVATE_KEY_EVM=
 
-# Stacks client credentials (use either mnemonic or private key)
+# Stacks client credentials (use one or the other)
 CLIENT_MNEMONIC_STACKS=
 CLIENT_PRIVATE_KEY_STACKS=
+
+# Server URL for client testing
+SERVER_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ accepts: [
   { scheme: "exact", network: "stacks:2147483648", asset: "STX", amount: "1000", ... }
 ]
 
-// 3. ROUTE by network (decode payload to check network prefix)
-const payload = decodePaymentSignature(paymentSignature);
+// 3. ROUTE by network (decode base64 JSON payload)
+const payload = JSON.parse(Buffer.from(paymentSignature, "base64").toString());
 if (payload.accepted.network.startsWith("stacks:")) {
   return stacksMiddleware(req, res, next);
 }

--- a/docs/FROM_EVM.md
+++ b/docs/FROM_EVM.md
@@ -137,8 +137,8 @@ app.get("/api/data", async (req, res, next) => {
 1. **Client requests** `/api/data`
 2. **Server returns 402** with both EVM and Stacks payment options
 3. **Client chooses** their network and signs a transaction
-4. **Client retries** with payment header (`Payment-Signature` for EVM, `X-PAYMENT` for Stacks)
-5. **Server routes** to the appropriate verifier
+4. **Client retries** with `Payment-Signature` header (v2 unified format)
+5. **Server decodes** payload and routes by network
 6. **Facilitator verifies** and settles the payment
 7. **Server returns** the data
 
@@ -148,7 +148,7 @@ Your EVM clients see nothing different - they still get their EVM option and pay
 
 ## Stacks Token Options
 
-Stacks supports multiple tokens. Clients specify via `X-PAYMENT-TOKEN-TYPE` header:
+Stacks supports multiple tokens. With v2, the token type is embedded in the `extra.tokenType` field of the payment payload:
 
 | Token | Description | Use Case |
 |-------|-------------|----------|
@@ -181,10 +181,10 @@ extra: {
 
 | Version | Header | EVM | Stacks |
 |---------|--------|-----|--------|
-| v1 | `X-PAYMENT` | Supported | Supported |
-| v2 | `Payment-Signature` | Supported | Coming soon |
+| v1 | `X-PAYMENT` | ✓ | ✓ |
+| v2 | `Payment-Signature` | ✓ | ✓ |
 
-Coinbase's `@x402/express` handles both. For Stacks, currently use `X-PAYMENT` (v1). When v2 ships for Stacks, the middleware will handle both automatically.
+Coinbase's `@x402/express` handles both versions. Stacks now supports v2 with the unified `Payment-Signature` header (base64-encoded JSON payload).
 
 ---
 

--- a/docs/FROM_SOLANA.md
+++ b/docs/FROM_SOLANA.md
@@ -170,6 +170,8 @@ if (v1Payment && (v1Payment.startsWith("0x") || v1Payment.length > 500)) {
 
 ## Stacks Token Options
 
+Stacks supports multiple tokens. With v2, the token type is embedded in the `extra.tokenType` field:
+
 | Token | Description | Use Case |
 |-------|-------------|----------|
 | `STX` | Native Stacks token | Default, most liquid |
@@ -181,6 +183,7 @@ Configure which you accept:
 ```typescript
 extra: {
   acceptedTokens: ["STX", "sBTC", "USDCx"],
+  tokenType: "STX",  // Default token
 }
 ```
 
@@ -199,10 +202,10 @@ extra: {
 
 | Version | Header | Solana | Stacks |
 |---------|--------|--------|--------|
-| v1 | `X-PAYMENT` | Supported | Supported |
-| v2 | `Payment-Signature` | Supported | Coming soon |
+| v1 | `X-PAYMENT` | ✓ | ✓ |
+| v2 | `Payment-Signature` | ✓ | ✓ |
 
-Both PayAI's `x402-solana` and Solana Foundation's `x402-next` handle both versions.
+Both PayAI's `x402-solana` and Solana Foundation's `x402-next` handle both versions. Stacks now supports v2 with the unified `Payment-Signature` header (base64-encoded JSON payload).
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -188,10 +188,11 @@ Accept multiple tokens:
 ```typescript
 extra: {
   acceptedTokens: ["STX", "sBTC", "USDCx"],
+  tokenType: "STX",  // Default token
 }
 ```
 
-Clients specify which token via `X-PAYMENT-TOKEN-TYPE` header.
+With v2, the token type is embedded in the `extra.tokenType` field of the payment payload.
 
 ---
 
@@ -199,10 +200,10 @@ Clients specify which token via `X-PAYMENT-TOKEN-TYPE` header.
 
 | Version | Header | Status |
 |---------|--------|--------|
-| v1 | `X-PAYMENT` | Available now |
-| v2 | `Payment-Signature` | Coming soon |
+| v1 | `X-PAYMENT` | ✓ |
+| v2 | `Payment-Signature` | ✓ |
 
-When v2 ships, the middleware will handle both automatically.
+Both versions are supported. v2 uses a unified `Payment-Signature` header with base64-encoded JSON payload, matching the Coinbase x402 specification.
 
 ---
 


### PR DESCRIPTION
## Summary

- Update README.md to v2 protocol with `Payment-Signature` header pattern
- Mark Stacks v2 as supported in all docs (FROM_EVM.md, FROM_SOLANA.md, GETTING_STARTED.md)
- Update flow descriptions to reflect v2 unified header format
- Simplify .env.example and add SERVER_URL for client testing

Closes #1

## Test plan

- [x] All markdown files updated correctly
- [x] Protocol version tables show ✓ for Stacks v2
- [x] Code examples use v2 patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)