### PR TITLE
ci: add release-please for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: node


### PR DESCRIPTION
## Summary

- Adds Release Please GitHub Action workflow for automated semantic versioning
- Workflow triggers on pushes to main branch
- Automatically bumps `package.json` version based on conventional commit types
- Generates CHANGELOG.md from commit history
- Creates GitHub releases when release PRs are merged

## Setup Required

After merging, enable in repo settings:

**Settings → Actions → General → Workflow permissions**
- Check: "Allow GitHub Actions to create and approve pull requests"

## How It Works

| Commit Type | Version Bump | Example |
|-------------|--------------|---------|
| `fix:` | Patch (0.1.0 → 0.1.1) | Bug fixes |
| `feat:` | Minor (0.1.0 → 0.2.0) | New features |
| `feat!:` or `BREAKING CHANGE:` | Major (0.1.0 → 1.0.0) | Breaking changes |
| `docs:`, `chore:`, `ci:` | No bump | Non-code changes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)