### PR TITLE
feat: upgrade to x402-stacks v2.0.1 with package verifier and types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ npm run check         # TypeScript type checking
 
 - **middleware-evm.ts**: Simplified EVM payment middleware (demo; production would use `@x402/express`)
 
-- **middleware-stacks.ts**: v2 Stacks payment middleware. Decodes `Payment-Signature` header, calls facilitator `/settle` endpoint. Supports STX, sBTC, and USDCx tokens.
+- **middleware-stacks.ts**: v2 Stacks payment middleware. Decodes `Payment-Signature` header, settles via `X402PaymentVerifier.settle()`. Supports STX, sBTC, and USDCx tokens.
 
 ### Hono Server (`src/server-hono/`)
 
@@ -53,13 +53,13 @@ Hono implementation with identical functionality to Express. Based on [aibtcdev/
 
 ### Shared (`src/shared/`)
 
-- **stacks-config.ts**: v2 types, configuration, and helper functions for Stacks payments
+- **stacks-config.ts**: Re-exports v2 types/constants from `x402-stacks`, project-specific configuration, token contracts, and helper functions
 
 ### Client (`src/client/`)
 
 - **evm-client.ts**: EVM payment flow demo (production would use `wrapFetchWithPayment` from `@x402/fetch`)
 
-- **stacks-client.ts**: v2 Stacks payment flow. Parses v2 402 response, signs with `X402PaymentClient`, builds v2 payload, and sends `Payment-Signature` header.
+- **stacks-client.ts**: v2 Stacks payment flow. Manual flow (parse v2 402, sign, `encodePaymentPayload()`) and auto flow (`createPaymentClient()` with axios).
 
 ## x402 v2 Payment Flow
 
@@ -73,7 +73,7 @@ Hono implementation with identical functionality to Express. Based on [aibtcdev/
 
 ## Key Dependencies
 
-- `x402-stacks` - Stacks transaction signing (used with v2 protocol)
+- `x402-stacks` (v2) - Stacks v2 types, `X402PaymentVerifier.settle()`, `createPaymentClient()`, `encodePaymentPayload()`
 - `@x402/express`, `@x402/hono`, `@x402/fetch`, `@x402/evm` - v2 Coinbase x402 for EVM
 - `hono`, `@hono/node-server` - Hono framework
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
         "hono": "^4.6.0",
-        "x402-stacks": "^1.1.1"
+        "x402-stacks": "^2.0.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -4953,9 +4953,9 @@
       }
     },
     "node_modules/x402-stacks": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/x402-stacks/-/x402-stacks-1.1.1.tgz",
-      "integrity": "sha512-wMWrU8EZjDCoq5LsPVQdD/HNm2bq0aNHySBkK56qeuHlV/BtMxay4oQ9W+GuWBIeEeCXqRsdeWltwj7cvF3k0A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/x402-stacks/-/x402-stacks-2.0.1.tgz",
+      "integrity": "sha512-/8tDDzzrsXLBsJptuaBo0qnC+qShBzHQSBRvWsTo/3JNyFLV8GaM9VytugG0cVb1zTQHYq3IJ11hE6/b+IdUpA==",
       "license": "MIT",
       "dependencies": {
         "@stacks/network": "^6.13.0",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "@x402/express": "^2.2.0",
     "@x402/fetch": "^2.2.0",
     "@x402/hono": "^2.2.0",
-    "x402-stacks": "^1.1.1",
-    "hono": "^4.6.0",
+    "dotenv": "^16.4.5",
     "express": "^4.21.0",
-    "dotenv": "^16.4.5"
+    "hono": "^4.6.0",
+    "x402-stacks": "^2.0.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/src/server-hono/index.ts
+++ b/src/server-hono/index.ts
@@ -10,7 +10,7 @@
  * - Routing: Based on decoded payload's "network" field (CAIP-2 format)
  *
  * This is the Hono equivalent of the Express server in src/server/.
- * See docs/INTEGRATION_GUIDE.md for step-by-step integration instructions.
+ * See docs/FROM_EVM.md for step-by-step integration instructions.
  */
 
 import { Hono } from "hono";
@@ -31,7 +31,8 @@ import {
 } from "./middleware-evm.js";
 import { createWeatherResponse } from "../shared/mock-data.js";
 import {
-  STACKS_NETWORK_IDS,
+  STACKS_NETWORKS,
+  networkToCAIP2,
   DEFAULT_ACCEPTED_TOKENS,
   DEFAULT_TIMEOUT_SECONDS,
   decodePaymentSignature,
@@ -78,7 +79,7 @@ app.get("/", (c) => {
         facilitator: evmConfig.facilitatorUrl,
       },
       stacks: {
-        network: STACKS_NETWORK_IDS[stacksConfig.network],
+        network: networkToCAIP2(stacksConfig.network),
         payTo: stacksConfig.payTo || "not-configured",
         facilitator: stacksConfig.facilitatorUrl,
       },
@@ -206,7 +207,7 @@ app.get("/weather", async (c) => {
           // STACKS OPTION (STX)
           {
             scheme: "exact",
-            network: STACKS_NETWORK_IDS[stacksConfig.network], // "stacks:1" or "stacks:2147483648"
+            network: networkToCAIP2(stacksConfig.network), // CAIP-2: "stacks:1" or "stacks:2147483648"
             asset: "STX",
             amount: "1000", // Amount in microSTX
             payTo: stacksConfig.payTo,
@@ -220,7 +221,7 @@ app.get("/weather", async (c) => {
           // STACKS OPTION (sBTC)
           {
             scheme: "exact",
-            network: STACKS_NETWORK_IDS[stacksConfig.network],
+            network: networkToCAIP2(stacksConfig.network),
             asset: getAssetIdentifier("sBTC", stacksConfig.network),
             amount: "100", // Amount in satoshis
             payTo: stacksConfig.payTo,

--- a/src/server-hono/middleware-evm.ts
+++ b/src/server-hono/middleware-evm.ts
@@ -51,17 +51,20 @@ export function evmPaymentMiddleware<E extends { Variables: EvmX402Variables }>(
     if (!paymentHeader) {
       return c.json(
         {
-          x402Version: 1,
+          x402Version: 2,
           error: "Payment Required",
+          resource: {
+            url: c.req.path,
+            description,
+            mimeType: "application/json",
+          },
           accepts: [
             {
               scheme: "exact",
               network: evmConfig.network,
-              maxAmountRequired: amount,
+              amount,
               asset: evmConfig.asset,
               payTo: evmConfig.payTo,
-              resource: c.req.path,
-              description,
               maxTimeoutSeconds: 300,
               extra: {
                 facilitator: evmConfig.facilitatorUrl,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,7 +9,7 @@
  * - 402 response: Uses "amount" and separate "resource" object
  * - Routing: Based on decoded payload's "network" field (CAIP-2 format)
  *
- * See docs/INTEGRATION_GUIDE.md for step-by-step integration instructions.
+ * See docs/FROM_EVM.md for step-by-step integration instructions.
  */
 
 import express from "express";
@@ -22,7 +22,8 @@ import {
 } from "../shared/mock-data.js";
 import {
   stacksConfig,
-  STACKS_NETWORK_IDS,
+  STACKS_NETWORKS,
+  networkToCAIP2,
   DEFAULT_ACCEPTED_TOKENS,
   DEFAULT_TIMEOUT_SECONDS,
   decodePaymentSignature,
@@ -174,7 +175,7 @@ app.get("/weather", async (req, res) => {
         // STACKS OPTION (STX)
         {
           scheme: "exact",
-          network: STACKS_NETWORK_IDS[stacksConfig.network], // "stacks:1" or "stacks:2147483648"
+          network: networkToCAIP2(stacksConfig.network), // CAIP-2: "stacks:1" or "stacks:2147483648"
           asset: "STX",
           amount: "1000", // Amount in microSTX
           payTo: stacksConfig.payTo,
@@ -188,7 +189,7 @@ app.get("/weather", async (req, res) => {
         // STACKS OPTION (sBTC)
         {
           scheme: "exact",
-          network: STACKS_NETWORK_IDS[stacksConfig.network],
+          network: networkToCAIP2(stacksConfig.network),
           asset: getAssetIdentifier("sBTC", stacksConfig.network),
           amount: "100", // Amount in satoshis
           payTo: stacksConfig.payTo,

--- a/src/server/middleware-evm.ts
+++ b/src/server/middleware-evm.ts
@@ -62,20 +62,26 @@ evmPaymentMiddleware.use((req, res, next) => {
     }
 
     return res.status(402).json({
-      x402Version: 1,
+      x402Version: 2,
+      error: "Payment Required",
+      resource: {
+        url: req.originalUrl,
+        description: routeConfig.config.description,
+        mimeType: "application/json",
+      },
       accepts: [
         {
           scheme: "exact",
           network: evmConfig.network,
-          maxAmountRequired: routeConfig.price === "$0.001" ? "1000" : "10000",
-          resource: req.originalUrl,
-          description: routeConfig.config.description,
-          payTo: evmConfig.payTo,
+          amount: routeConfig.price === "$0.001" ? "1000" : "10000",
           asset: evmConfig.asset,
+          payTo: evmConfig.payTo,
+          maxTimeoutSeconds: 300,
+          extra: {
+            facilitator: evmConfig.facilitatorUrl,
+          },
         },
       ],
-      error: "Payment Required",
-      message: "X-Payment header with signed transaction required",
     });
   }
 


### PR DESCRIPTION
## Summary

- Upgrade `x402-stacks` from `^1.1.1` to `^2.0.1`, replacing custom v2 implementations with package-provided types, functions, and the `X402PaymentVerifier.settle()` API
- **Critical fix**: Settlement now uses the package's `X402PaymentVerifier.settle()` which handles the correct facilitator API format internally, instead of a custom `settleWithFacilitatorV2()` that called `/settle` directly with a potentially mismatched request format
- Update all documentation to show v2 patterns exclusively

### Changes

| File | Change |
|------|--------|
| `package.json` | Bump x402-stacks ^1.1.1 → ^2.0.1 |
| `src/shared/stacks-config.ts` | Remove custom types/functions, re-export from package |
| `src/server/middleware-stacks.ts` | Use `X402PaymentVerifier.settle()` + `X402_HEADERS` |
| `src/server-hono/middleware-stacks.ts` | Mirror Express changes for Hono |
| `src/server/index.ts` | Use `networkToCAIP2()`, fix doc ref |
| `src/server-hono/index.ts` | Mirror Express changes for Hono |
| `src/client/stacks-client.ts` | Use `encodePaymentPayload()`, add `createPaymentClient()` auto-flow |
| `src/server/middleware-evm.ts` | v2 402 response format (x402Version: 2, amount, resource object) |
| `src/server-hono/middleware-evm.ts` | v2 402 response format |
| `docs/FROM_EVM.md` | v2 patterns throughout |
| `docs/FROM_SOLANA.md` | v2 patterns throughout |
| `docs/GETTING_STARTED.md` | v2 patterns throughout |
| `CLAUDE.md` | Updated dependency and architecture descriptions |

## Test plan

- [x] `npm run check` — TypeScript compiles cleanly
- [x] `npm run start` — Express server starts without errors
- [x] `npm run start:hono` — Hono server starts without errors
- [x] `curl localhost:3000/weather` returns v2 402 format with `x402Version: 2`, `resource` object, and `amount` fields
- [ ] `npm run client:stacks` — End-to-end Stacks payment test (requires credentials)
- [ ] `npm run client:evm` — End-to-end EVM payment test (requires credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)