### PR TITLE
feat: add self-hosting docs and payment option helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,10 @@ Hono implementation with identical functionality to Express. Based on [aibtcdev/
 
 ### Shared (`src/shared/`)
 
-- **stacks-config.ts**: Re-exports v2 types/constants from `x402-stacks`, project-specific configuration, token contracts, and helper functions
+- **stacks-config.ts**: Re-exports v2 types/constants from `x402-stacks`, project-specific configuration, token contracts, and helper functions:
+  - `toBaseUnits()` / `fromBaseUnits()` - Amount conversion (e.g., "1.5" STX ↔ "1500000" microSTX)
+  - `createPaymentOption()` - Build a single payment option for a token
+  - `createStacksTokenOptions()` - Build payment options for multiple tokens at once
 
 ### Client (`src/client/`)
 
@@ -178,6 +181,8 @@ Tokens configured in `stacks-config.ts` with mainnet/testnet contracts. Token ty
 - [Add Stacks to EVM](docs/FROM_EVM.md) - For Base developers
 - [Add Stacks to Solana](docs/FROM_SOLANA.md) - For Solana developers
 - [Getting Started](docs/GETTING_STARTED.md) - Build Stacks x402 from scratch
+- [Self-Hosting](docs/SELF_HOSTING.md) - Run your own facilitator
 - [x402-stacks NPM](https://www.npmjs.com/package/x402-stacks) - TypeScript client/server
-- [Stacks Facilitator](https://github.com/x402Stacks/x402-stacks-facilitator) - Payment verification
+- [x402-stacks-facilitator](https://github.com/x402Stacks/x402-stacks-facilitator) - Lightweight Go facilitator
+- [OpenFacilitator](https://github.com/rawgroundbeef/OpenFacilitator) - Multi-network platform with dashboard
 - [Sponsor Relay](https://github.com/aibtcdev/x402-sponsor-relay) - Gasless transactions for Stacks

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Add **Stacks payment support** to your existing x402 app. Whether you're on **EV
 | EVM/Base app with `@x402/express` | [Add Stacks to EVM](docs/FROM_EVM.md) |
 | Solana app with `x402-solana` or `x402-next` | [Add Stacks to Solana](docs/FROM_SOLANA.md) |
 | Nothing yet, starting fresh | [Getting Started with Stacks x402](docs/GETTING_STARTED.md) |
+| Need your own facilitator | [Self-Hosting Guide](docs/SELF_HOSTING.md) |
 
 ## Quick Start
 
@@ -83,6 +84,10 @@ See [x402 v2 spec](https://github.com/coinbase/x402/blob/main/specs/x402-specifi
 - [Stacks Facilitator](https://facilitator.stacksx402.com) - Payment verification
 - [Stacks x402 Spec](https://github.com/aibtcdev/x402/blob/feature/add-stacks-ecosystem/specs/schemes/exact/scheme_exact_stacks.md)
 - [Sponsor Relay](https://github.com/aibtcdev/x402-sponsor-relay) - Gasless transactions
+
+### Self-Hosted Facilitators
+- [x402-stacks-facilitator](https://github.com/x402Stacks/x402-stacks-facilitator) - Lightweight Go facilitator
+- [OpenFacilitator](https://github.com/rawgroundbeef/OpenFacilitator) - Multi-network platform with dashboard
 
 ### x402 Protocol
 - [x402.org](https://x402.org) - Protocol home

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,0 +1,155 @@
+# Self-Hosting a Stacks Facilitator
+
+By default, this example uses the public Stacks facilitator at `https://facilitator.stacksx402.com`. For production deployments, you may want to run your own facilitator for control, reliability, or privacy.
+
+## Facilitator Options
+
+| Option | Language | Best For |
+|--------|----------|----------|
+| [x402-stacks-facilitator](https://github.com/x402Stacks/x402-stacks-facilitator) | Go | Lightweight, stateless, single-network |
+| [OpenFacilitator](https://github.com/rawgroundbeef/OpenFacilitator) | TypeScript | Multi-tenant, dashboard UI, EVM + Solana + Stacks |
+
+---
+
+## Option 1: x402-stacks-facilitator (Go)
+
+Stateless Go service. No database required. Stacks-only.
+
+### Quick Start
+
+```bash
+git clone https://github.com/x402Stacks/x402-stacks-facilitator
+cd x402-stacks-facilitator
+
+# Run with Docker
+docker-compose up -d
+
+# Or run locally (Go 1.24+)
+go run ./cmd/server/main.go
+```
+
+Your facilitator runs at `http://localhost:8080`.
+
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `8080` | Server port |
+
+### API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/health` | GET | Health check |
+| `/verify` | POST | Verify existing transaction |
+| `/settle` | POST | Broadcast and confirm transaction |
+
+### Usage
+
+Update your `.env`:
+
+```bash
+STACKS_FACILITATOR_URL=http://localhost:8080
+```
+
+---
+
+## Option 2: OpenFacilitator (TypeScript)
+
+Full-featured platform with dashboard UI. Supports EVM, Solana, and Stacks.
+
+### Quick Start
+
+```bash
+git clone https://github.com/rawgroundbeef/openfacilitator
+cd openfacilitator
+
+# Run with Docker
+docker compose up -d
+```
+
+- API: `http://localhost:3001`
+- Dashboard: `http://localhost:3002`
+
+### Or Use Managed Service
+
+Visit [openfacilitator.io](https://openfacilitator.io):
+- **$5/mo** with custom domain and auto-SSL
+
+### Features
+
+- Multi-tenant (host for multiple merchants)
+- Dashboard for wallet management
+- Supports EVM (Base), Solana, and Stacks
+- Built-in authentication (Better Auth)
+- PostgreSQL or SQLite
+
+### Stacks Configuration
+
+After deployment, configure Stacks in the dashboard:
+
+1. Go to Networks → Stacks
+2. Generate or import a Stacks wallet
+3. Select mainnet or testnet
+
+The facilitator wallet receives payments and can be withdrawn via the dashboard.
+
+### Usage
+
+Update your `.env` with your OpenFacilitator instance:
+
+```bash
+STACKS_FACILITATOR_URL=https://your-facilitator.example.com
+```
+
+---
+
+## Facilitator Flow
+
+```
+Client                    Server                    Facilitator
+   │                         │                           │
+   │── GET /api/data ───────▶│                           │
+   │◀── 402 + accepts[] ─────│                           │
+   │                         │                           │
+   │── sign tx locally ──────│                           │
+   │                         │                           │
+   │── GET /api/data ───────▶│                           │
+   │   + Payment-Signature   │── POST /settle ──────────▶│
+   │                         │                           │── broadcast tx
+   │                         │                           │── poll for confirm
+   │                         │◀── { success, txId } ─────│
+   │◀── 200 + data ──────────│                           │
+```
+
+The facilitator:
+1. Receives the signed transaction from your server
+2. Broadcasts it to the Stacks network
+3. Polls for confirmation
+4. Returns success/failure to your server
+
+---
+
+## Security Considerations
+
+- **HTTPS**: Always use HTTPS in production
+- **Rate limiting**: Add rate limiting to prevent abuse
+- **Monitoring**: Monitor facilitator health and transaction success rates
+- **Wallet security**: For OpenFacilitator, the facilitator wallet holds funds temporarily. Withdraw regularly.
+
+---
+
+## Choosing Between Options
+
+| Consideration | x402-stacks-facilitator | OpenFacilitator |
+|---------------|-------------------------|-----------------|
+| Setup complexity | Lower | Higher |
+| Multi-network | Stacks only | EVM + Solana + Stacks |
+| Dashboard | None | Full UI |
+| Database | None (stateless) | PostgreSQL/SQLite |
+| Multi-tenant | No | Yes |
+| Resource usage | Lower | Higher |
+
+For Stacks-only deployments with minimal overhead, use **x402-stacks-facilitator**.
+
+For multi-network support or merchant onboarding, use **OpenFacilitator**.


### PR DESCRIPTION
## Summary

- Add `docs/SELF_HOSTING.md` comparing x402-stacks-facilitator (Go) vs OpenFacilitator (TypeScript)
- Add helper utilities to `stacks-config.ts`: `toBaseUnits()`, `fromBaseUnits()`, `createPaymentOption()`, `createStacksTokenOptions()`
- Update README with self-hosting guide and facilitator links

Related to work done in:
- rawgroundbeef/OpenFacilitator#6 (Stacks support for OpenFacilitator)
- rawgroundbeef/x402.jobs#2 (SDK helpers)

## Test plan

- [x] TypeScript compiles (`npm run check`)
- [ ] Review self-hosting doc accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)